### PR TITLE
Fix performance issues in getPunishments and implement caching for count queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+/.idea/

--- a/src/app/(app)/history/page.tsx
+++ b/src/app/(app)/history/page.tsx
@@ -1,4 +1,3 @@
-import { db } from "@/lib/db";
 import { SearchParams } from "@/types";
 import p from "@/lib/language/utils/parse";
 import { language } from "@/lib/language/dictionaries";
@@ -13,21 +12,18 @@ export async function generateMetadata() {
   
   const { dictionary } = await language();
 
-  const banCount = await db.litebans_bans.count();
-  const muteCount = await db.litebans_mutes.count();
-  const warnCount = await db.litebans_warnings.count();
-  const kickCount = await db.litebans_kicks.count();
+  const { bans, mutes, warns, kicks } = await getPunishmentCount();
   
   return {
     title: dictionary.pages.history.title,
     openGraph: {
       images: process.env.SITE_URL + siteConfig.logo,
       description: p(siteConfig.openGraph.pages.history.description, {
-        bans: banCount,
-        mutes: muteCount,
-        warns: warnCount,
-        kicks: kickCount,
-        total: banCount + muteCount + warnCount + kickCount
+        bans: bans,
+        mutes: mutes,
+        warns: warns,
+        kicks: kicks,
+        total: bans + mutes + warns + kicks
       })
     }
   }

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,4 +1,3 @@
-import { db } from "@/lib/db";
 import { SearchParams } from "@/types";
 import { siteConfig } from "@config/site";
 import p from "@/lib/language/utils/parse";
@@ -10,21 +9,21 @@ import { Icons } from "@/components/layout/icons";
 import { DefaultPage } from "@/components/layout/default-page";
 import { HistoryTable } from "@/components/punishments/history/history-table";
 import { PunishmentTypeCard } from "@/components/punishments/punishment-type-card";
+import {getPunishmentCount} from "@/lib/punishment/punishment";
 
 export async function generateMetadata() {
-  
   const { dictionary } = await language();
-  
+  const { bans, mutes, warns, kicks } = await getPunishmentCount();
   return {
     title: dictionary.pages.home.title,
     openGraph: {
       images: process.env.SITE_URL + siteConfig.logo,
       description: p(siteConfig.openGraph.pages.main.description, {
-        bans: await db.litebans_bans.count(),
-        mutes: await db.litebans_mutes.count(),
-        warns: await db.litebans_warnings.count(),
-        kicks: await db.litebans_kicks.count(),
-        total: await db.litebans_bans.count() + await db.litebans_mutes.count() + await db.litebans_warnings.count() + await db.litebans_kicks.count()
+        bans: bans,
+        mutes: mutes,
+        warns: warns,
+        kicks: kicks,
+        total: bans + mutes + warns + kicks
       })
     }
   }
@@ -33,10 +32,7 @@ export async function generateMetadata() {
 export default async function Home(searchParams: SearchParams) {
   const { dictionary } = await language();
 
-  const banCount = await db.litebans_bans.count();
-  const muteCount = await db.litebans_mutes.count();
-  const warnCount = await db.litebans_warnings.count();
-  const kickCount = await db.litebans_kicks.count();
+  const { bans, mutes, warns, kicks } = await getPunishmentCount();
 
   const page = getPage(searchParams);
   const player = getPlayer(searchParams);
@@ -46,40 +42,40 @@ export default async function Home(searchParams: SearchParams) {
     <DefaultPage
       title={siteConfig.title}
       description={p(dictionary.pages.home.subtitle, {
-        bans: banCount,
-        mutes: muteCount,
-        warns: warnCount,
-        kicks: kickCount,
-        total: banCount + muteCount + warnCount + kickCount
+        bans: bans,
+        mutes: mutes,
+        warns: warns,
+        kicks: kicks,
+        total: bans + mutes + warns + kicks
       })}
       className="w-full space-y-6"
     >
       <div className="mx-auto grid gap-4 sm:grid-cols-2 sm:w-[496px] lg:grid-cols-4 lg:w-[1024px]">
         <PunishmentTypeCard
-          title={q(dictionary.words.bans, banCount)}
+          title={q(dictionary.words.bans, bans)}
           fromGradient="from-red-500/10"
-          count={banCount}
+          count={bans}
           href="/bans"
           punishmentIcon={Icons.ban({ color: 'red', className: "size-[8.5rem] opacity-20 absolute top-[-35px] right-[-25px] blur-sm transition duration-700 group-hover:opacity-40 group-hover:scale-[1.15]" })}
         />
         <PunishmentTypeCard
-          title={q(dictionary.words.mutes, muteCount)}
+          title={q(dictionary.words.mutes, mutes)}
           fromGradient="from-neutral-500/10"
-          count={muteCount}
+          count={mutes}
           href="/mutes"
           punishmentIcon={Icons.mute({ color: 'gray', className: "size-[8.5rem] opacity-20 absolute top-[-35px] right-[-25px] blur-sm transition duration-700 group-hover:opacity-40 group-hover:scale-[1.15]" })}
         />
         <PunishmentTypeCard
-          title={q(dictionary.words.warns, warnCount)}
+          title={q(dictionary.words.warns, warns)}
           fromGradient="from-yellow-600/10"
-          count={warnCount}
+          count={warns}
           href="/warns"
           punishmentIcon={Icons.warn({ className: "size-[8.5rem] opacity-20 absolute top-[-35px] right-[-25px] text-yellow-500 ml-2 blur-sm transition duration-700 group-hover:opacity-40 group-hover:scale-[1.15]" })}
         />
         <PunishmentTypeCard
-          title={q(dictionary.words.kicks, kickCount)}
+          title={q(dictionary.words.kicks, kicks)}
           fromGradient="from-sky-600/5"
-          count={kickCount}
+          count={kicks}
           href="/kicks"
           punishmentIcon={Icons.kick({ className: "size-[8.5rem] opacity-20 absolute top-[-35px] right-[-25px] text-sky-600 ml-2 blur-sm transition duration-700 group-hover:opacity-40 group-hover:scale-110" })}
         />

--- a/src/lib/punishment/player.ts
+++ b/src/lib/punishment/player.ts
@@ -1,4 +1,8 @@
 import { db } from "../db";
+import {getWarnCount} from "@/lib/punishment/warn";
+import {getKickCount} from "@/lib/punishment/kick";
+import {getMuteCount} from "@/lib/punishment/mute";
+import {getBanCount} from "@/lib/punishment/ban";
 
 const getPlayerByName = async (name: string) => {
   const player = await db.litebans_history.findFirst({
@@ -18,43 +22,19 @@ const getPlayerByName = async (name: string) => {
 }
 
 const getPlayerBanCount = async (uuid: string) => {
-  const count = await db.litebans_bans.count({
-    where: {
-      uuid
-    }
-  });
-
-  return count;
+    return await getBanCount(uuid);
 }
 
 const getPlayerMuteCount = async (uuid: string) => {
-  const count = await db.litebans_mutes.count({
-    where: {
-      uuid
-    }
-  });
-
-  return count;
+    return await getMuteCount(uuid);
 }
 
 const getPlayerWarnCount = async (uuid: string) => {
-  const count = await db.litebans_warnings.count({
-    where: {
-      uuid
-    }
-  });
-
-  return count;
+    return await getWarnCount(uuid);
 }
 
 const getPlayerKickCount = async (uuid: string) => {
-  const count = await db.litebans_kicks.count({
-    where: {
-      uuid
-    }
-  });
-
-  return count;
+    return await getKickCount(uuid);
 }
 
 export { getPlayerByName, getPlayerBanCount, getPlayerMuteCount, getPlayerWarnCount, getPlayerKickCount}

--- a/src/lib/punishment/punishment.ts
+++ b/src/lib/punishment/punishment.ts
@@ -4,32 +4,16 @@ import { PunishmentListItem } from "@/types";
 
 import { db } from "../db";
 import { Dictionary } from "../language/types";
+import {getBanCount} from "@/lib/punishment/ban";
+import {getMuteCount} from "@/lib/punishment/mute";
+import {getWarnCount} from "@/lib/punishment/warn";
+import {getKickCount} from "@/lib/punishment/kick";
 
 const getPunishmentCount = async (player?: string, staff?: string) => {
-  const bans = await db.litebans_bans.count({
-    where: {
-      uuid: player,
-      banned_by_uuid: staff
-    }
-  });
-  const mutes = await db.litebans_mutes.count({
-    where: {
-      uuid: player,
-      banned_by_uuid: staff
-    }
-  });
-  const warns = await db.litebans_warnings.count({
-    where: {
-      uuid: player,
-      banned_by_uuid: staff
-    }
-  });
-  const kicks = await db.litebans_kicks.count({
-    where: {
-      uuid: player,
-      banned_by_uuid: staff
-    }
-  });
+  const bans = await getBanCount(player, staff);
+  const mutes = await getMuteCount(player, staff);
+  const warns = await getWarnCount(player, staff);
+  const kicks = await getKickCount(player, staff);
 
   return { bans, mutes, warns, kicks }
 }

--- a/src/lib/punishment/punishment.ts
+++ b/src/lib/punishment/punishment.ts
@@ -51,21 +51,58 @@ const getPlayerName = async (uuid: string) => {
 }
 
 const getPunishments = async (page: number, player?: string, staff?: string) => {
-  const query = Prisma.sql`
-  SELECT id, uuid, banned_by_name, banned_by_uuid, reason, time, until, active, 'ban' AS type FROM litebans_bans ${player || staff ? Prisma.sql`WHERE ` : Prisma.sql``}${player ? Prisma.sql` uuid = ${player} ` : Prisma.sql``} ${player && staff ? Prisma.sql`AND` : Prisma.sql``} ${staff ? Prisma.sql` banned_by_uuid = ${staff}` : Prisma.sql``}
-  UNION ALL 
-  SELECT id, uuid, banned_by_name, banned_by_uuid, reason, time, until, active, 'mute' AS type FROM litebans_mutes ${player || staff ? Prisma.sql`WHERE ` : Prisma.sql``}${player ? Prisma.sql` uuid = ${player} ` : Prisma.sql``} ${player && staff ? Prisma.sql`AND` : Prisma.sql``} ${staff ? Prisma.sql` banned_by_uuid = ${staff}` : Prisma.sql``}
-  UNION ALL 
-  SELECT id, uuid, banned_by_name, banned_by_uuid, reason, time, until, active, 'warn' AS type FROM litebans_warnings ${player || staff ? Prisma.sql`WHERE ` : Prisma.sql``}${player ? Prisma.sql` uuid = ${player} ` : Prisma.sql``} ${player && staff ? Prisma.sql`AND` : Prisma.sql``} ${staff ? Prisma.sql` banned_by_uuid = ${staff}` : Prisma.sql``}
-  UNION ALL 
-  SELECT id, uuid, banned_by_name, banned_by_uuid, reason, time, until, active, 'kick' AS type FROM litebans_kicks ${player || staff ? Prisma.sql`WHERE ` : Prisma.sql``}${player ? Prisma.sql` uuid = ${player} ` : Prisma.sql``} ${player && staff ? Prisma.sql`AND` : Prisma.sql``} ${staff ? Prisma.sql` banned_by_uuid = ${staff}` : Prisma.sql``}
-  ORDER BY time DESC
-  LIMIT 10
-  OFFSET ${(page - 1) * 10}
-  `
-  const punishments = await db.$queryRaw(query) as PunishmentListItem[];
+    const pageSize = 10;
+    const offset = (page - 1) * pageSize;
+    const subqueryLimit = offset + pageSize;
 
-  return punishments;
+    const query = Prisma.sql`
+    SELECT * FROM (
+      SELECT * FROM (
+        SELECT id, uuid, banned_by_name, banned_by_uuid, reason, time, until, active, 'ban' AS type
+        FROM litebans_bans
+        WHERE 1=1
+          ${player ? Prisma.sql`AND uuid = ${player}` : Prisma.sql``}
+          ${staff ? Prisma.sql`AND banned_by_uuid = ${staff}` : Prisma.sql``}
+        ORDER BY time DESC
+          LIMIT ${subqueryLimit}
+      ) bans
+      UNION ALL
+      SELECT * FROM (
+        SELECT id, uuid, banned_by_name, banned_by_uuid, reason, time, until, active, 'mute' AS type
+        FROM litebans_mutes
+        WHERE 1=1
+          ${player ? Prisma.sql`AND uuid = ${player}` : Prisma.sql``}
+          ${staff ? Prisma.sql`AND banned_by_uuid = ${staff}` : Prisma.sql``}
+        ORDER BY time DESC
+          LIMIT ${subqueryLimit}
+      ) mutes
+      UNION ALL
+      SELECT * FROM (
+        SELECT id, uuid, banned_by_name, banned_by_uuid, reason, time, until, active, 'warn' AS type
+        FROM litebans_warnings
+        WHERE 1=1
+          ${player ? Prisma.sql`AND uuid = ${player}` : Prisma.sql``}
+          ${staff ? Prisma.sql`AND banned_by_uuid = ${staff}` : Prisma.sql``}
+        ORDER BY time DESC
+          LIMIT ${subqueryLimit}
+      ) warns
+      UNION ALL
+      SELECT * FROM (
+        SELECT id, uuid, banned_by_name, banned_by_uuid, reason, time, until, active, 'kick' AS type
+        FROM litebans_kicks
+        WHERE 1=1
+          ${player ? Prisma.sql`AND uuid = ${player}` : Prisma.sql``}
+          ${staff ? Prisma.sql`AND banned_by_uuid = ${staff}` : Prisma.sql``}
+        ORDER BY time DESC
+          LIMIT ${subqueryLimit}
+      ) kicks
+      ORDER BY time DESC
+        LIMIT ${pageSize}
+      OFFSET ${offset}
+    ) final_result
+  `;
+
+    return await db.$queryRaw(query) as PunishmentListItem[];
 }
 
 const sanitizePunishments = async (dictionary: Dictionary, punishments: PunishmentListItem[]) => {


### PR DESCRIPTION
Currently, each call to getPunishments unites all rows from all tables before executing the actual query. This behavior is caused by UNION ALL.
To fix this, the four queries are now executed separately and their results are combined. This change is included in first commit.

Each SELECT COUNT(*) query takes a lot of time if your database has many rows. To fix this, caching has been implemented. I also noticed there were many direct database calls from .tsx files, so I centralized them and added caching for getBanCount, getKickCount, getMuteCount, and getWarnCount. This significantly reduces load times for large databases (for me, from 12s to 300ms). My database has around 1.2 million records in each table. It was fixed in second commit.